### PR TITLE
Use format instead of concat

### DIFF
--- a/ob-elasticsearch.el
+++ b/ob-elasticsearch.el
@@ -95,7 +95,7 @@ Does not move the point."
                     (shell-command-on-region
                      (point-min)
                      (point-max)
-                     (concat es-jq-path " '" jq-header "'")
+                     (format "%s '%s'" es-jq-path jq-header)
                      (current-buffer)
                      t)))
                 (buffer-string))


### PR DESCRIPTION
When I use something like this in :jq [.hits.hits[]._source.message[0]] concat is failing. So format is an ideal replacement.
